### PR TITLE
Statically link to wt

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,54 @@ project(
   default_options: ['cpp_std=c++26'],
 ) # TODO warning_level/werror
 
+### Configure wt ###
+#   - everything off except SSL so we can use HTTPS requests to search Arch repo
+#   - static linking
+cmake = import('cmake')
+opt_var = cmake.subproject_options()
+opt_var.add_cmake_defines(
+  {
+    'ENABLE_SSL': 'ON',
+    'ENABLE_HARU': 'OFF',
+    'ENABLED_PANGO': 'OFF',
+    'ENABLE_PANGO': 'OFF',
+    'ENABLE_SQLITE': 'OFF',
+    'ENABLE_POSTGRES': 'OFF',
+    'ENABLE_FIREBIRD': 'OFF',
+    'ENABLE_MYSQL': 'OFF',
+    'ENABLE_MSSQLSERVER': 'OFF',
+    'ENABLE_QT4': 'OFF',
+    'ENABLE_QT5': 'OFF',
+    'ENABLE_QT6': 'OFF',
+    'ENABLE_SAML': 'OFF',
+    'ENABLE_LIBWTTEST': 'OFF',
+    'ENABLE_LIBWTDBO': 'OFF',
+    'ENABLE_OPENGL': 'OFF',
+    'ENABLE_UNWIND': 'OFF',
+    'HTTP_WITH_ZLIB': 'OFF',
+    'WT_CPP17_FILESYSTEM_IMPLEMENTATION': 'std', # rather than boost
+    'WT_CPP20_DATE_TZ_IMPLEMENTATION': 'std', # rather than boost
+    'CONNECTOR_HTTP': 'ON',
+    'CONNECTOR_FCGI': 'OFF',
+    'BUILD_TESTS': 'OFF',
+    'INSTALL_DOCUMENTATION': 'OFF',
+    'INSTALL_THEMES': 'OFF',
+    'INSTALL_RESOURCES': 'OFF',
+    'SHARED_LIBS': false,
+    'Boost_USE_STATIC_LIBS': true,
+  },
+)
+
+opt_var.set_override_option('CMAKE_CXX_STANDARD_REQUIRED', 'ON')
+opt_var.set_override_option('cpp_std', 'c++23')
+
+wt_proj = cmake.subproject('wt', options: opt_var)
+
+wt_dep = wt_proj.dependency('wt')
+wthttp_dep = wt_proj.dependency('wthttp')
+
+### build options ###
+
 if (get_option('skip_validation'))
   add_project_arguments('-DWALI_SKIP_VALIDATION', language: 'cpp')
 endif
@@ -18,18 +66,17 @@ if (get_option('fake_data'))
   add_project_arguments('-DWALI_FAKE_DATA', language: 'cpp')
 endif
 
+### other deps ###
+
 # plog logging library
 subproject('sergiusthebest-plog')
 plog_dep = dependency('plog') #header only, but points meson to the include dir
-
-# dependency() does not find wthttp lib
-wthttp_dep = meson.get_compiler('cpp').find_library('wthttp', required: true)
-wt_dep = dependency('wt', required: true)
 
 # libmount and libmount
 blkid_dep = dependency('blkid', required: true)
 libmount_dep = dependency('mount', required: true)
 
+### sources ##
 includes = include_directories(['include'])
 sources = [
   'src/Wali.cpp',

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,16 +11,8 @@ curl -OL https://github.com/ccooper1982/wali/releases/download/$VERSION/wali-bin
 # Extract
 tar -xf wali-bin_$VERSION.tar.gz -C /usr/local/bin
 
-# Install
-mount -o remount,size=600M /run/archiso/cowspace
-
-# accurate time required for package verification
+# wali does this but lets ensure time is accurate before we start
 timedatectl
-
-pacman-key --init
-#pacman-key --refresh-keys
-pacman -Sy --noconfirm archlinux-keyring
-pacman -Q wt || pacman -Sy --noconfirm wt
 
 echo
 echo "--------------"

--- a/subprojects/wt.wrap
+++ b/subprojects/wt.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://github.com/emweb/wt.git
+revision = 4.12.1
+depth = 1
+
+[provide]
+wt_dep = wt, wthttp


### PR DESCRIPTION
- Rather than installing `wt` from pacman, the repo is cloned and built 
- It is configured to build a statc library, and link statically to boost
- Only features required are enabled (http, and SSL for HTTPS requests to the Arch repo)

This means the `wali` binary has increased size from 800K to 10M, but it avoids installing `wt` in the live environment